### PR TITLE
Deprecated Fix setShouldEndSession

### DIFF
--- a/src/main/java/ai/nitro/bot4j/integration/alexa/impl/Bot4jSpeechletImpl.java
+++ b/src/main/java/ai/nitro/bot4j/integration/alexa/impl/Bot4jSpeechletImpl.java
@@ -62,7 +62,7 @@ public class Bot4jSpeechletImpl implements Bot4jSpeechlet {
 		speech.setText("Bye");
 
 		final SpeechletResponse result = SpeechletResponse.newTellResponse(speech);
-		result.setShouldEndSession(true);
+		result.setNullableShouldEndSession(true);
 
 		return result;
 	}
@@ -72,7 +72,7 @@ public class Bot4jSpeechletImpl implements Bot4jSpeechlet {
 		speech.setText("Ok");
 
 		final SpeechletResponse result = SpeechletResponse.newTellResponse(speech);
-		result.setShouldEndSession(false);
+		result.setNullableShouldEndSession(false);
 
 		return result;
 	}
@@ -133,7 +133,7 @@ public class Bot4jSpeechletImpl implements Bot4jSpeechlet {
 			result = SpeechletResponse.newTellResponse(speech, card);
 		}
 
-		result.setShouldEndSession(alexaMessageSender.getShouldEndSession());
+		result.setNullableShouldEndSession(alexaMessageSender.getShouldEndSession());
 
 		return result;
 	}
@@ -156,7 +156,7 @@ public class Bot4jSpeechletImpl implements Bot4jSpeechlet {
 		speech.setText("Bye");
 
 		final SpeechletResponse result = SpeechletResponse.newTellResponse(speech);
-		result.setShouldEndSession(true);
+		result.setNullableShouldEndSession(true);
 
 		return result;
 	}


### PR DESCRIPTION
/**
     * Sets whether or not the session should end with this response.
     *
     * @param shouldEndSession
     *            {@code true} if the session should end with this response
     *
     * @deprecated with version 1.4.0 {@code null} value is allowed.
     *            See {@link #setNullableShouldEndSession(Boolean)}
     */
    @Deprecated
    public void setShouldEndSession(final boolean shouldEndSession) {
        this.shouldEndSession = shouldEndSession;
    }

===>

/**
     * Sets value of shouldEndSession attribute
     * <p> Set it to {@code true} to end session
     * <p> Set it to {@code false} to keep session open and wait for a voice command or response
     * <p> Set it to {@code null} to keep session open without waiting for a voice command when
     *            displaying template. If no template is displayed it will default to
     *            previous behavior and end session.
     * <p> Refer to online documentation for more details.
     *
     * @param shouldEndSession
     *            new value of shouldEndSession attribute
     */
    public void setNullableShouldEndSession(final Boolean shouldEndSession) {
        this.shouldEndSession = shouldEndSession;
    }

